### PR TITLE
fix recursive call caused by namespace confusion if memcache enabled

### DIFF
--- a/system/core/cache/driver/Memcache.php
+++ b/system/core/cache/driver/Memcache.php
@@ -31,7 +31,7 @@ class Memcache extends Cache {
         $this->options = $options;
         $this->options['expire'] = isset( $options['expire'] ) ? $options['expire'] : 0;
         $func = $options['persistent'] ? 'pconnect' : 'connect';
-        $this->instance = new memcache;
+        $this->instance = new \Memcache;
         $options['timeout'] === false ?
                         $this->instance->$func( $options['host'], $options['port'] ) :
                         $this->instance->$func( $options['host'], $options['port'], $options['timeout'] );


### PR DESCRIPTION
后台开启memcache后出现无限递归，系不同命名空间下类名相同没有使用FQN导致。

刚看了一下redis也有类似问题。
